### PR TITLE
[feat] 주문 API 구현

### DIFF
--- a/src/main/java/gc/cafe/api/controller/order/OrderController.java
+++ b/src/main/java/gc/cafe/api/controller/order/OrderController.java
@@ -4,6 +4,7 @@ import gc.cafe.api.ApiResponse;
 import gc.cafe.api.controller.order.request.OrderCreateRequest;
 import gc.cafe.api.service.order.OrderService;
 import gc.cafe.api.service.order.response.OrderResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +19,7 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping("/new")
-    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(@RequestBody OrderCreateRequest request) {
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(@Valid @RequestBody OrderCreateRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(orderService.createOrder(request.toServiceRequest())));
     }
 

--- a/src/main/java/gc/cafe/api/controller/order/request/OrderCreateRequest.java
+++ b/src/main/java/gc/cafe/api/controller/order/request/OrderCreateRequest.java
@@ -1,32 +1,42 @@
 package gc.cafe.api.controller.order.request;
 
 import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
-import gc.cafe.domain.order.OrderStatus;
-import gc.cafe.domain.orderproduct.OrderProduct;
-import jakarta.persistence.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 public class OrderCreateRequest {
 
+    @Email(message = "이메일 형식이어야 합니다.")
+    @Size(max = 50, message = "이메일은 50자 이하여야 합니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 
+    @Size(max = 200, message = "주소는 200자 이하여야 합니다.")
+    @NotBlank(message = "주소는 필수입니다.")
     private String address;
 
+    @Size(max = 20, message = "우편번호는 20자 이하여야 합니다.")
+    @NotBlank(message = "우편번호는 필수입니다.")
     private String postcode;
 
-    private List<Long> productsIds;
+    @Valid
+    @NotNull(message = "주문 할 상품은 필수입니다.")
+    private List<OrderProductQuantity> orderProductsQuantity;
 
     @Builder
-    private OrderCreateRequest(String email, String address, String postcode, List<Long> productsIds) {
+    private OrderCreateRequest(String email, String address, String postcode, List<OrderProductQuantity> orderProductsQuantity) {
         this.email = email;
         this.address = address;
         this.postcode = postcode;
-        this.productsIds = productsIds;
+        this.orderProductsQuantity = orderProductsQuantity;
     }
 
     public OrderCreateServiceRequest toServiceRequest() {
@@ -34,7 +44,7 @@ public class OrderCreateRequest {
             .email(email)
             .address(address)
             .postcode(postcode)
-            .productsIds(productsIds)
+            .orderProductQuantity(orderProductsQuantity)
             .build();
     }
 }

--- a/src/main/java/gc/cafe/api/controller/order/request/OrderProductQuantity.java
+++ b/src/main/java/gc/cafe/api/controller/order/request/OrderProductQuantity.java
@@ -1,0 +1,23 @@
+package gc.cafe.api.controller.order.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrderProductQuantity {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    @Positive(message = "상품 수량은 1 이상이어야 합니다.")
+    private int quantity;
+
+    @Builder
+    private OrderProductQuantity(Long productId, int quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -11,11 +11,13 @@ import gc.cafe.domain.product.Product;
 import gc.cafe.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class OrderServiceImpl implements OrderService {
 
@@ -38,9 +40,13 @@ public class OrderServiceImpl implements OrderService {
         return OrderResponse.of(savedOrder);
     }
 
+
     @Override
+    @Transactional(readOnly = true)
     public OrderResponse getOrder(Long id) {
-        return null;
+        Order order = orderRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 주문 id : " + id + "를 가진 주문이 존재하지 않습니다."));
+        return OrderResponse.of(order);
     }
 
     @Override

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -23,20 +23,17 @@ public class OrderServiceImpl implements OrderService {
 
     private final ProductRepository productRepository;
 
-    /*
-    * TODO : create 메서드가 서비스 레이어에서 사용되는 request를 모르는 상태로 변경 필요
-    *  : create 테스트 코드 작성 필요
-    * 왜냐하면 패키지간 의존성이 생기기 때문에 서비스 레이어에서 사용되는 request를 모르는 상태로 변경해야 함
-    * 서비스 레이어에서 도메인 레이어로 내려 줄 때는 도메인 레이어의 객체를 사용해야 함
-    * 근데 인자가 3개 이하인게 좋다고 했음, 근데 이럴 경우엔 어떻게 내려줘야됨 ?
-    * request 대신에 여기서 파라미터를 통해 하나씩 만들어서 내려주면 된다고 생각이 드는데 그러면 인자가 너무많아짐
-    * Order로 내려준다? 그러면 굳이 create를 만들 필요가있나 ?
-    * */
     @Override
     public OrderResponse createOrder(OrderCreateServiceRequest request) {
         Set<Long> productIds = request.getOrderProducts().keySet();
         List<Product> products = productRepository.findAllById(productIds);
-        Order order = Order.create(request,products);
+        Order order = Order.builder()
+            .email(request.getEmail())
+            .address(request.getAddress())
+            .postcode(request.getPostcode())
+            .orderProducts(request.getOrderProducts())
+            .products(products)
+            .build();
         Order savedOrder = orderRepository.save(order);
         return OrderResponse.of(savedOrder);
     }

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -2,11 +2,9 @@ package gc.cafe.api.service.order;
 
 
 import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
-import gc.cafe.api.service.order.request.OrdersByEmailServiceRequest;
 import gc.cafe.api.service.order.response.OrderResponse;
 import gc.cafe.domain.order.Order;
 import gc.cafe.domain.order.OrderRepository;
-import gc.cafe.domain.order.OrderStatus;
 import gc.cafe.domain.product.Product;
 import gc.cafe.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Set;
 
-import static gc.cafe.domain.order.OrderStatus.*;
+import static gc.cafe.domain.order.OrderStatus.DELIVERING;
+import static gc.cafe.domain.order.OrderStatus.ORDERED;
 
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -51,6 +51,10 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public List<OrderResponse> getOrdersByEmail(String email) {
-        return List.of();
+        List<Order> orders = orderRepository.findByEmail(email);
+
+        return orders.stream()
+            .map(OrderResponse::of)
+            .toList();
     }
 }

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -4,17 +4,41 @@ package gc.cafe.api.service.order;
 import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
 import gc.cafe.api.service.order.request.OrdersByEmailServiceRequest;
 import gc.cafe.api.service.order.response.OrderResponse;
+import gc.cafe.domain.order.Order;
+import gc.cafe.domain.order.OrderRepository;
+import gc.cafe.domain.order.OrderStatus;
+import gc.cafe.domain.product.Product;
+import gc.cafe.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @Service
 public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+
+    private final ProductRepository productRepository;
+
+    /*
+    * TODO : create 메서드가 서비스 레이어에서 사용되는 request를 모르는 상태로 변경 필요
+    *  : create 테스트 코드 작성 필요
+    * 왜냐하면 패키지간 의존성이 생기기 때문에 서비스 레이어에서 사용되는 request를 모르는 상태로 변경해야 함
+    * 서비스 레이어에서 도메인 레이어로 내려 줄 때는 도메인 레이어의 객체를 사용해야 함
+    * 근데 인자가 3개 이하인게 좋다고 했음, 근데 이럴 경우엔 어떻게 내려줘야됨 ?
+    * request 대신에 여기서 파라미터를 통해 하나씩 만들어서 내려주면 된다고 생각이 드는데 그러면 인자가 너무많아짐
+    * Order로 내려준다? 그러면 굳이 create를 만들 필요가있나 ?
+    * */
     @Override
     public OrderResponse createOrder(OrderCreateServiceRequest request) {
-        return null;
+        Set<Long> productIds = request.getOrderProducts().keySet();
+        List<Product> products = productRepository.findAllById(productIds);
+        Order order = Order.create(request,products);
+        Order savedOrder = orderRepository.save(order);
+        return OrderResponse.of(savedOrder);
     }
 
     @Override

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -10,11 +10,14 @@ import gc.cafe.domain.order.OrderStatus;
 import gc.cafe.domain.product.Product;
 import gc.cafe.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
+
+import static gc.cafe.domain.order.OrderStatus.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -56,5 +59,13 @@ public class OrderServiceImpl implements OrderService {
         return orders.stream()
             .map(OrderResponse::of)
             .toList();
+    }
+
+    @Scheduled(cron = "0 0 14 * * *")
+    private void sendOrder() {
+        List<Order> orders = orderRepository.findByOrderStatus(ORDERED);
+
+        orders.forEach(order -> order.updateStatus(DELIVERING));
+
     }
 }

--- a/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
+++ b/src/main/java/gc/cafe/api/service/order/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import gc.cafe.domain.order.OrderStatus;
 import gc.cafe.domain.product.Product;
 import gc.cafe.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,11 +62,11 @@ public class OrderServiceImpl implements OrderService {
             .toList();
     }
 
+    @Async("threadPoolTaskExecutor")
     @Scheduled(cron = "0 0 14 * * *")
-    private void sendOrder() {
+    protected void sendOrder() {
         List<Order> orders = orderRepository.findByOrderStatus(ORDERED);
 
         orders.forEach(order -> order.updateStatus(DELIVERING));
-
     }
 }

--- a/src/main/java/gc/cafe/api/service/order/request/OrderCreateServiceRequest.java
+++ b/src/main/java/gc/cafe/api/service/order/request/OrderCreateServiceRequest.java
@@ -1,22 +1,29 @@
 package gc.cafe.api.service.order.request;
 
+import gc.cafe.api.controller.order.request.OrderProductQuantity;
 import lombok.Builder;
+import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
+@Getter
 public class OrderCreateServiceRequest {
 
     private String email;
     private String address;
     private String postcode;
-    private List<Long> productsIds;
+    private Map<Long, Integer> orderProducts;
 
 
     @Builder
-    private OrderCreateServiceRequest(String email, String address, String postcode, List<Long> productsIds) {
+    private OrderCreateServiceRequest(String email, String address, String postcode, List<OrderProductQuantity> orderProductQuantity) {
         this.email = email;
         this.address = address;
         this.postcode = postcode;
-        this.productsIds = productsIds;
+        this.orderProducts = orderProductQuantity.stream()
+            .collect(HashMap::new, (map, orderProduct) -> map.put(orderProduct.getProductId(), orderProduct.getQuantity()), HashMap::putAll);
     }
 }

--- a/src/main/java/gc/cafe/api/service/order/response/OrderResponse.java
+++ b/src/main/java/gc/cafe/api/service/order/response/OrderResponse.java
@@ -1,5 +1,6 @@
 package gc.cafe.api.service.order.response;
 
+import gc.cafe.domain.order.Order;
 import gc.cafe.domain.order.OrderStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,5 +25,22 @@ public class OrderResponse {
         this.postcode = postcode;
         this.orderStatus = orderStatus;
         this.orderDetails = orderDetails;
+    }
+
+    public static OrderResponse of(Order order) {
+        return OrderResponse.builder()
+            .id(order.getId())
+            .email(order.getEmail())
+            .address(order.getAddress())
+            .postcode(order.getPostcode())
+            .orderStatus(order.getOrderStatus())
+            .orderDetails(order.getOrderProducts().stream()
+                .map(orderProduct -> OrderDetailResponse.builder()
+                    .category(orderProduct.getProduct().getCategory())
+                    .price(orderProduct.getProduct().getPrice())
+                    .quantity(orderProduct.getQuantity())
+                    .build())
+                .toList())
+            .build();
     }
 }

--- a/src/main/java/gc/cafe/config/AsyncConfig.java
+++ b/src/main/java/gc/cafe/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package gc.cafe.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("Executor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/gc/cafe/domain/order/Order.java
+++ b/src/main/java/gc/cafe/domain/order/Order.java
@@ -51,4 +51,8 @@ public class Order extends BaseEntity {
             .map(product -> new OrderProduct(this, product, orderProducts.get(product.getId())))
             .collect(Collectors.toList());
     }
+
+    public void updateStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/gc/cafe/domain/order/Order.java
+++ b/src/main/java/gc/cafe/domain/order/Order.java
@@ -42,25 +42,13 @@ public class Order extends BaseEntity {
     private List<OrderProduct> orderProducts = new ArrayList<>();
 
     @Builder
-    private Order(String email, String address, String postcode, OrderStatus orderStatus, List<Product> products, Map<Long,Integer> orderProducts) {
+    private Order(String email, String address, String postcode, List<Product> products, Map<Long,Integer> orderProducts) {
         this.email = email;
         this.address = address;
         this.postcode = postcode;
-        this.orderStatus = orderStatus;
+        this.orderStatus = OrderStatus.ORDERED;
         this.orderProducts = products.stream()
             .map(product -> new OrderProduct(this, product, orderProducts.get(product.getId())))
             .collect(Collectors.toList());
-    }
-
-
-    public static Order create(OrderCreateServiceRequest request, List<Product> products) {
-        return Order.builder()
-            .email(request.getEmail())
-            .address(request.getAddress())
-            .postcode(request.getPostcode())
-            .orderStatus(OrderStatus.ORDERED)
-            .products(products)
-            .orderProducts(request.getOrderProducts())
-            .build();
     }
 }

--- a/src/main/java/gc/cafe/domain/order/Order.java
+++ b/src/main/java/gc/cafe/domain/order/Order.java
@@ -1,6 +1,5 @@
 package gc.cafe.domain.order;
 
-import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
 import gc.cafe.domain.BaseEntity;
 import gc.cafe.domain.orderproduct.OrderProduct;
 import gc.cafe.domain.product.Product;

--- a/src/main/java/gc/cafe/domain/order/Order.java
+++ b/src/main/java/gc/cafe/domain/order/Order.java
@@ -1,14 +1,19 @@
 package gc.cafe.domain.order;
 
+import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
 import gc.cafe.domain.BaseEntity;
 import gc.cafe.domain.orderproduct.OrderProduct;
+import gc.cafe.domain.product.Product;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,4 +41,26 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderProduct> orderProducts = new ArrayList<>();
 
+    @Builder
+    private Order(String email, String address, String postcode, OrderStatus orderStatus, List<Product> products, Map<Long,Integer> orderProducts) {
+        this.email = email;
+        this.address = address;
+        this.postcode = postcode;
+        this.orderStatus = orderStatus;
+        this.orderProducts = products.stream()
+            .map(product -> new OrderProduct(this, product, orderProducts.get(product.getId())))
+            .collect(Collectors.toList());
+    }
+
+
+    public static Order create(OrderCreateServiceRequest request, List<Product> products) {
+        return Order.builder()
+            .email(request.getEmail())
+            .address(request.getAddress())
+            .postcode(request.getPostcode())
+            .orderStatus(OrderStatus.ORDERED)
+            .products(products)
+            .orderProducts(request.getOrderProducts())
+            .build();
+    }
 }

--- a/src/main/java/gc/cafe/domain/order/OrderRepository.java
+++ b/src/main/java/gc/cafe/domain/order/OrderRepository.java
@@ -1,7 +1,8 @@
 package gc.cafe.domain.order;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrderRepository {
+public interface OrderRepository extends JpaRepository<Order, Long> {
 }

--- a/src/main/java/gc/cafe/domain/order/OrderRepository.java
+++ b/src/main/java/gc/cafe/domain/order/OrderRepository.java
@@ -3,6 +3,11 @@ package gc.cafe.domain.order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    List<Order> findByEmail(String email);
+
 }

--- a/src/main/java/gc/cafe/domain/order/OrderRepository.java
+++ b/src/main/java/gc/cafe/domain/order/OrderRepository.java
@@ -10,4 +10,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByEmail(String email);
 
+    List<Order> findByOrderStatus(OrderStatus orderStatus);
 }

--- a/src/main/java/gc/cafe/domain/orderproduct/OrderProduct.java
+++ b/src/main/java/gc/cafe/domain/orderproduct/OrderProduct.java
@@ -35,4 +35,11 @@ public class OrderProduct extends BaseEntity {
     @Column(nullable = false)
     private int quantity;
 
+    public OrderProduct(Order order, Product product, int quantity) {
+        this.order = order;
+        this.product = product;
+        this.category = product.getCategory();
+        this.price = product.getPrice();
+        this.quantity = quantity;
+    }
 }

--- a/src/test/java/gc/cafe/ControllerTestSupport.java
+++ b/src/test/java/gc/cafe/ControllerTestSupport.java
@@ -1,7 +1,9 @@
 package gc.cafe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gc.cafe.api.controller.order.OrderController;
 import gc.cafe.api.controller.product.ProductController;
+import gc.cafe.api.service.order.OrderService;
 import gc.cafe.api.service.product.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -9,7 +11,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
-    ProductController.class
+    ProductController.class,
+    OrderController.class
 })
 public abstract class ControllerTestSupport {
 
@@ -21,4 +24,7 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected ProductService productService;
+
+    @MockBean
+    protected OrderService orderService;
 }

--- a/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
+++ b/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
@@ -1,24 +1,18 @@
 package gc.cafe.api.controller.order;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import gc.cafe.ControllerTestSupport;
 import gc.cafe.api.controller.order.request.OrderCreateRequest;
 import gc.cafe.api.controller.order.request.OrderProductQuantity;
-import gc.cafe.api.service.order.OrderService;
 import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
 import gc.cafe.api.service.order.response.OrderDetailResponse;
 import gc.cafe.api.service.order.response.OrderResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.MediaType;
 
 import java.util.List;
 
-import static gc.cafe.domain.order.OrderStatus.DELIVERING;
 import static gc.cafe.domain.order.OrderStatus.ORDERED;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;

--- a/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
+++ b/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
@@ -1,0 +1,682 @@
+package gc.cafe.api.controller.order;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import gc.cafe.ControllerTestSupport;
+import gc.cafe.api.controller.order.request.OrderCreateRequest;
+import gc.cafe.api.controller.order.request.OrderProductQuantity;
+import gc.cafe.api.service.order.OrderService;
+import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
+import gc.cafe.api.service.order.response.OrderDetailResponse;
+import gc.cafe.api.service.order.response.OrderResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static gc.cafe.domain.order.OrderStatus.ORDERED;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OrderControllerTest extends ControllerTestSupport {
+
+
+    @DisplayName("신규 주문을 생성한다.")
+    @Test
+    void createOrder() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+        given(orderService.createOrder(any(OrderCreateServiceRequest.class)))
+            .willReturn(
+                OrderResponse.builder()
+                    .id(1L)
+                    .orderStatus(ORDERED)
+                    .email("test@gmail.com")
+                    .address("서울시 강남구")
+                    .postcode("125454")
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build());
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+            .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
+            .andExpect(jsonPath("$.data.postcode").value("125454"))
+            .andExpect(jsonPath("$.data.orderDetails").isArray())
+            .andExpect(jsonPath("$.data.orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data.orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 이메일은 이메일 형식이어야 한다.")
+    @Test
+    void createOrderWithEmailForm() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("이메일 형식이어야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 이메일은 필수값이다.")
+    @Test
+    void createOrderWithoutEmail() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("이메일은 필수입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 이메일은 50자 이하여야 한다.")
+    @Test
+    void createOrderWhenEmailLengthIsOver50() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email(generateFixedLengthString(41)+"@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("이메일은 50자 이하여야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 이메일은 50자 이하여야 한다.")
+    @Test
+    void createOrderWhenEmailLengthIs0() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email(generateFixedLengthString(40)+"@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+        given(orderService.createOrder(any(OrderCreateServiceRequest.class)))
+            .willReturn(
+                OrderResponse.builder()
+                    .id(1L)
+                    .orderStatus(ORDERED)
+                    .email(generateFixedLengthString(40)+"@gmail.com")
+                    .address("서울시 강남구")
+                    .postcode("125454")
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build());
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data.email").value(generateFixedLengthString(40)+"@gmail.com"))
+            .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
+            .andExpect(jsonPath("$.data.postcode").value("125454"))
+            .andExpect(jsonPath("$.data.orderDetails").isArray())
+            .andExpect(jsonPath("$.data.orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data.orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 주소는 필수값이다.")
+    @Test
+    void createOrderWithoutAddress() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("주소는 필수입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 주소는 200자 이하여야 한다.")
+    @Test
+    void createOrderWhenAddressLengthIsOver200() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address(generateFixedLengthString(201))
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("주소는 200자 이하여야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 주소는 200자 이하여야 한다.")
+    @Test
+    void createOrderWhenAddressLengthIs200() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address(generateFixedLengthString(200))
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+        given(orderService.createOrder(any(OrderCreateServiceRequest.class)))
+            .willReturn(
+                OrderResponse.builder()
+                    .id(1L)
+                    .orderStatus(ORDERED)
+                    .email("test@gmail.com")
+                    .address(generateFixedLengthString(200))
+                    .postcode("125454")
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build());
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+            .andExpect(jsonPath("$.data.address").value(generateFixedLengthString(200)))
+            .andExpect(jsonPath("$.data.postcode").value("125454"))
+            .andExpect(jsonPath("$.data.orderDetails").isArray())
+            .andExpect(jsonPath("$.data.orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data.orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 우편번호는 필수값이다.")
+    @Test
+    void createOrderWithoutPostcode() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("우편번호는 필수입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 우편번호는 20자 이하여야 한다.")
+    @Test
+    void createOrderWhenPostcodeLengthIsOver20() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode(generateFixedLengthString(21))
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("우편번호는 20자 이하여야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 우편번호는 20자 이하여야 한다.")
+    @Test
+    void createOrderWhenPostcodeLengthIs200() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode(generateFixedLengthString(20))
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+        given(orderService.createOrder(any(OrderCreateServiceRequest.class)))
+            .willReturn(
+                OrderResponse.builder()
+                    .id(1L)
+                    .orderStatus(ORDERED)
+                    .email("test@gmail.com")
+                    .address("서울시 강남구")
+                    .postcode(generateFixedLengthString(20))
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build());
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+            .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
+            .andExpect(jsonPath("$.data.postcode").value(generateFixedLengthString(20)))
+            .andExpect(jsonPath("$.data.orderDetails").isArray())
+            .andExpect(jsonPath("$.data.orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data.orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 상품은 필수값이다.")
+    @Test
+    void createOrderWithoutProduct() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("주문 할 상품은 필수입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 상품ID는 필수값이다.")
+    @Test
+    void createOrderWithoutProductId() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("상품 ID는 필수입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 수량은 필수값이다.")
+    @Test
+    void createOrderWithoutProductQuantity() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("상품 수량은 1 이상이어야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("신규 주문을 생성 할 때 상품 수량은 양의 정수이다.")
+    @Test
+    void createOrderWhenProductQuantityIsZero() throws Exception {
+        OrderCreateRequest request = OrderCreateRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(0)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
+            .build();
+
+
+        mockMvc.perform(
+                post("/api/v1/orders/new")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)
+                    ))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400"))
+            .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("상품 수량은 1 이상이어야 합니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+    private static String generateFixedLengthString(int length) {
+        return "나".repeat(length);
+    }
+
+
+}

--- a/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
+++ b/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 
 import java.util.List;
 
+import static gc.cafe.domain.order.OrderStatus.DELIVERING;
 import static gc.cafe.domain.order.OrderStatus.ORDERED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -728,6 +729,63 @@ class OrderControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
             .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
             .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+
+    }
+
+    @DisplayName("이메일을 통해 주문을 조회한다.")
+    @Test
+    void getOrderByEmail() throws Exception {
+        //given
+        String email = "test@gmail.com";
+
+        given(orderService.getOrdersByEmail(email))
+            .willReturn(List.of(
+                OrderResponse.builder()
+                    .id(1L)
+                    .email(email)
+                    .address("서울시 강남구")
+                    .postcode("125454")
+                    .orderStatus(ORDERED)
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build()
+            ));
+
+        mockMvc.perform(
+                get("/api/v1/orders")
+                    .param("email", email)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data[0].id").value(1L))
+            .andExpect(jsonPath("$.data[0].orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data[0].email").value("test@gmail.com"))
+            .andExpect(jsonPath("$.data[0].address").value("서울시 강남구"))
+            .andExpect(jsonPath("$.data[0].postcode").value("125454"))
+            .andExpect(jsonPath("$.data[0].orderDetails").isArray())
+            .andExpect(jsonPath("$.data[0].orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data[0].orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data[0].orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data[0].orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data[0].orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data[0].orderDetails[1].category").value("음료"));
 
     }
 

--- a/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
+++ b/src/test/java/gc/cafe/api/controller/order/OrderControllerTest.java
@@ -20,6 +20,7 @@ import static gc.cafe.domain.order.OrderStatus.ORDERED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -171,7 +172,7 @@ class OrderControllerTest extends ControllerTestSupport {
     @Test
     void createOrderWhenEmailLengthIsOver50() throws Exception {
         OrderCreateRequest request = OrderCreateRequest.builder()
-            .email(generateFixedLengthString(41)+"@gmail.com")
+            .email(generateFixedLengthString(41) + "@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
             .orderProductsQuantity(
@@ -206,7 +207,7 @@ class OrderControllerTest extends ControllerTestSupport {
     @Test
     void createOrderWhenEmailLengthIs0() throws Exception {
         OrderCreateRequest request = OrderCreateRequest.builder()
-            .email(generateFixedLengthString(40)+"@gmail.com")
+            .email(generateFixedLengthString(40) + "@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
             .orderProductsQuantity(
@@ -228,7 +229,7 @@ class OrderControllerTest extends ControllerTestSupport {
                 OrderResponse.builder()
                     .id(1L)
                     .orderStatus(ORDERED)
-                    .email(generateFixedLengthString(40)+"@gmail.com")
+                    .email(generateFixedLengthString(40) + "@gmail.com")
                     .address("서울시 강남구")
                     .postcode("125454")
                     .orderDetails(
@@ -260,7 +261,7 @@ class OrderControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data").isMap())
             .andExpect(jsonPath("$.data.id").value(1L))
             .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
-            .andExpect(jsonPath("$.data.email").value(generateFixedLengthString(40)+"@gmail.com"))
+            .andExpect(jsonPath("$.data.email").value(generateFixedLengthString(40) + "@gmail.com"))
             .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
             .andExpect(jsonPath("$.data.postcode").value("125454"))
             .andExpect(jsonPath("$.data.orderDetails").isArray())
@@ -674,6 +675,63 @@ class OrderControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.message").value("상품 수량은 1 이상이어야 합니다."))
             .andExpect(jsonPath("$.data").isEmpty());
     }
+
+    @DisplayName("주문ID로 주문을 조회한다.")
+    @Test
+    void getOrderByOrderId() throws Exception {
+
+        Long pathValue = 1L;
+
+        given(orderService.getOrder(pathValue))
+            .willReturn(
+                OrderResponse.builder()
+                    .id(pathValue)
+                    .orderStatus(ORDERED)
+                    .email("test@gmail.com")
+                    .address("서울시 강남구")
+                    .postcode("125454")
+                    .orderDetails(
+                        List.of(
+                            OrderDetailResponse.builder()
+                                .price(1000L)
+                                .quantity(1)
+                                .category("원두")
+                                .build()
+                            ,
+                            OrderDetailResponse.builder()
+                                .price(2000L)
+                                .quantity(2)
+                                .category("음료")
+                                .build()
+                        ))
+                    .build());
+
+        mockMvc.perform(
+                get("/api/v1/orders/{id}", 1L)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.orderStatus").value("ORDERED"))
+            .andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+            .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
+            .andExpect(jsonPath("$.data.postcode").value("125454"))
+            .andExpect(jsonPath("$.data.orderDetails").isArray())
+            .andExpect(jsonPath("$.data.orderDetails[0].price").value(1000L))
+            .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+            .andExpect(jsonPath("$.data.orderDetails[0].category").value("원두"))
+            .andExpect(jsonPath("$.data.orderDetails[1].price").value(2000L))
+            .andExpect(jsonPath("$.data.orderDetails[1].quantity").value(2))
+            .andExpect(jsonPath("$.data.orderDetails[1].category").value("음료"));
+
+    }
+
+
     private static String generateFixedLengthString(int length) {
         return "나".repeat(length);
     }

--- a/src/test/java/gc/cafe/api/service/order/OrderServiceImplTest.java
+++ b/src/test/java/gc/cafe/api/service/order/OrderServiceImplTest.java
@@ -119,13 +119,13 @@ class OrderServiceImplTest extends IntegrationTestSupport {
             .description("에스프레소")
             .build();
 
-        productRepository.saveAll(List.of(product1, product2));
+        List<Product> products = productRepository.saveAll(List.of(product1, product2));
 
         Order order = Order.builder()
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .orderProducts(Map.of(products.get(0).getId(), 1, products.get(1).getId(), 2))
             .products(List.of(
                 product1,
                 product2
@@ -182,13 +182,13 @@ class OrderServiceImplTest extends IntegrationTestSupport {
             .description("에스프레소")
             .build();
 
-        productRepository.saveAll(List.of(product1, product2));
+        List<Product> products = productRepository.saveAll(List.of(product1, product2));
 
         Order order1 = Order.builder()
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .orderProducts(Map.of(products.get(0).getId(), 1, products.get(1).getId(), 2))
             .products(List.of(
                 product1,
                 product2
@@ -199,7 +199,7 @@ class OrderServiceImplTest extends IntegrationTestSupport {
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 2, 2L, 4))
+            .orderProducts(Map.of(products.get(0).getId(), 2, products.get(1).getId(), 4))
             .products(List.of(
                 product1,
                 product2
@@ -252,13 +252,13 @@ class OrderServiceImplTest extends IntegrationTestSupport {
             .description("에스프레소")
             .build();
 
-        productRepository.saveAll(List.of(product1, product2));
+        List<Product> products = productRepository.saveAll(List.of(product1, product2));
 
         Order order1 = Order.builder()
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .orderProducts(Map.of(products.get(0).getId(), 1, products.get(1).getId(), 2))
             .products(List.of(
                 product1,
                 product2
@@ -269,7 +269,7 @@ class OrderServiceImplTest extends IntegrationTestSupport {
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 2, 2L, 4))
+            .orderProducts(Map.of(products.get(0).getId(), 2, products.get(1).getId(), 4))
             .products(List.of(
                 product1,
                 product2

--- a/src/test/java/gc/cafe/api/service/order/OrderServiceImplTest.java
+++ b/src/test/java/gc/cafe/api/service/order/OrderServiceImplTest.java
@@ -1,0 +1,104 @@
+package gc.cafe.api.service.order;
+
+import gc.cafe.IntegrationTestSupport;
+import gc.cafe.api.controller.order.request.OrderProductQuantity;
+import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
+import gc.cafe.api.service.order.response.OrderDetailResponse;
+import gc.cafe.api.service.order.response.OrderResponse;
+import gc.cafe.domain.order.Order;
+import gc.cafe.domain.order.OrderRepository;
+import gc.cafe.domain.order.OrderStatus;
+import gc.cafe.domain.product.Product;
+import gc.cafe.domain.product.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static gc.cafe.domain.order.OrderStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+class OrderServiceImplTest extends IntegrationTestSupport {
+
+    @Autowired
+    private OrderServiceImpl orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+
+    @DisplayName("상품을 주문한다.")
+    @Test
+    void createOrder() {
+        //given
+        Product product1 = Product.builder()
+            .name("스타벅스 원두")
+            .category("원두")
+            .price(50000L)
+            .description("에티오피아산")
+            .build();
+
+        Product product2 = Product.builder()
+            .name("스타벅스 라떼")
+            .category("음료")
+            .price(3000L)
+            .description("에스프레소")
+            .build();
+
+        productRepository.saveAll(List.of(product1, product2));
+
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProductQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build(),
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                )
+            )
+            .build();
+
+        //when
+        OrderResponse response = orderService.createOrder(request);
+
+        List<Order> orders = orderRepository.findAll();
+
+        //then
+        assertThat(orders).hasSize(1)
+            .extracting("id", "email", "address", "postcode", "orderStatus")
+            .containsExactlyInAnyOrder(
+                tuple(orders.get(0).getId(), "test@gmail.com", "서울시 강남구", "125454", ORDERED)
+            );
+
+        assertThat(response)
+            .extracting("id", "email", "address", "postcode", "orderStatus")
+            .containsExactlyInAnyOrder(
+                response.getId(), "test@gmail.com", "서울시 강남구", "125454", ORDERED
+            );
+
+        assertThat(response.getOrderDetails())
+            .hasSize(2)
+            .extracting("category", "price","quantity")
+            .containsExactlyInAnyOrder(
+                tuple("원두", 50000L, 1),
+                tuple("음료", 3000L, 2)
+            );
+    }
+
+}

--- a/src/test/java/gc/cafe/config/AsyncTestConfig.java
+++ b/src/test/java/gc/cafe/config/AsyncTestConfig.java
@@ -1,0 +1,28 @@
+package gc.cafe.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SyncTaskExecutor;
+
+@TestConfiguration
+public class AsyncTestConfig {
+
+    @Bean
+    public AsyncExecutorPostProcessor asyncExecutorPostProcessor() {
+        return new AsyncExecutorPostProcessor();
+    }
+
+    static class AsyncExecutorPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (beanName.equals("threadPoolTaskExecutor")) {
+                return new SyncTaskExecutor();
+            }
+            return bean;
+        }
+    }
+
+}

--- a/src/test/java/gc/cafe/docs/order/OrderControllerDocsTest.java
+++ b/src/test/java/gc/cafe/docs/order/OrderControllerDocsTest.java
@@ -2,7 +2,7 @@ package gc.cafe.docs.order;
 
 import gc.cafe.api.controller.order.OrderController;
 import gc.cafe.api.controller.order.request.OrderCreateRequest;
-import gc.cafe.api.controller.order.request.OrdersByEmailRequest;
+import gc.cafe.api.controller.order.request.OrderProductQuantity;
 import gc.cafe.api.service.order.OrderService;
 import gc.cafe.api.service.order.request.OrderCreateServiceRequest;
 import gc.cafe.api.service.order.response.OrderDetailResponse;
@@ -47,7 +47,18 @@ public class OrderControllerDocsTest extends RestDocsSupport {
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .productsIds(List.of(1L, 2L))
+            .orderProductsQuantity(
+                List.of(
+                    OrderProductQuantity.builder()
+                        .productId(1L)
+                        .quantity(1)
+                        .build()
+                    ,
+                    OrderProductQuantity.builder()
+                        .productId(2L)
+                        .quantity(2)
+                        .build()
+                ))
             .build();
 
         given(orderService.createOrder(any(OrderCreateServiceRequest.class)))
@@ -95,8 +106,12 @@ public class OrderControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("postcode").type(JsonFieldType.STRING)
                         .description("주문자 우편번호")
                         .attributes(field("constraints", "최대 20자")),
-                    fieldWithPath("productsIds").type(JsonFieldType.ARRAY)
-                        .description("주문 상품 ID를 담은 배열")
+                    fieldWithPath("orderProductsQuantity").type(JsonFieldType.ARRAY)
+                        .description("주문 상품 목록"),
+                    fieldWithPath("orderProductsQuantity[].productId").type(JsonFieldType.NUMBER)
+                        .description("상품 ID"),
+                    fieldWithPath("orderProductsQuantity[].quantity").type(JsonFieldType.NUMBER)
+                        .description("상품 수량")
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER)

--- a/src/test/java/gc/cafe/domain/order/OrderRepositoryTest.java
+++ b/src/test/java/gc/cafe/domain/order/OrderRepositoryTest.java
@@ -51,13 +51,13 @@ class OrderRepositoryTest extends IntegrationTestSupport {
             .description("베이글")
             .build();
 
-        productRepository.saveAll(List.of(product1, product2,product3));
+        List<Product> products = productRepository.saveAll(List.of(product1, product2, product3));
 
         Order order1 = Order.builder()
             .email(email)
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .orderProducts(Map.of(products.get(0).getId(), 1, products.get(1).getId(), 2))
             .products(List.of(
                 product1,
                 product2
@@ -68,7 +68,7 @@ class OrderRepositoryTest extends IntegrationTestSupport {
             .email(email)
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 2, 3L, 4))
+            .orderProducts(Map.of(products.get(0).getId(), 2, products.get(2).getId(), 4))
             .products(List.of(
                 product1,
                 product3
@@ -129,13 +129,13 @@ class OrderRepositoryTest extends IntegrationTestSupport {
             .description("베이글")
             .build();
 
-        productRepository.saveAll(List.of(product1, product2,product3));
+        List<Product> products = productRepository.saveAll(List.of(product1, product2, product3));
 
         Order order1 = Order.builder()
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .orderProducts(Map.of(products.get(0).getId(), 1, products.get(1).getId(), 2))
             .products(List.of(
                 product1,
                 product2
@@ -146,7 +146,7 @@ class OrderRepositoryTest extends IntegrationTestSupport {
             .email("test@gmail.com")
             .address("서울시 강남구")
             .postcode("125454")
-            .orderProducts(Map.of(1L, 2, 3L, 4))
+            .orderProducts(Map.of(products.get(0).getId(), 2, products.get(2).getId(), 4))
             .products(List.of(
                 product1,
                 product3

--- a/src/test/java/gc/cafe/domain/order/OrderRepositoryTest.java
+++ b/src/test/java/gc/cafe/domain/order/OrderRepositoryTest.java
@@ -1,0 +1,181 @@
+package gc.cafe.domain.order;
+
+import gc.cafe.IntegrationTestSupport;
+import gc.cafe.domain.product.Product;
+import gc.cafe.domain.product.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static gc.cafe.domain.order.OrderStatus.ORDERED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@Transactional
+class OrderRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @DisplayName("이메일을 통해 주문 목록을 조회한다.")
+    @Test
+    void findOrdersByEmail() {
+        //given
+        String email = "test@gmail.com";
+
+        Product product1 = Product.builder()
+            .name("스타벅스 원두")
+            .category("원두")
+            .price(50000L)
+            .description("에티오피아산")
+            .build();
+
+        Product product2 = Product.builder()
+            .name("스타벅스 라떼")
+            .category("음료")
+            .price(3000L)
+            .description("에스프레소")
+            .build();
+
+        Product product3 = Product.builder()
+            .name("스타벅스 베이글")
+            .category("베이커리")
+            .price(5000L)
+            .description("베이글")
+            .build();
+
+        productRepository.saveAll(List.of(product1, product2,product3));
+
+        Order order1 = Order.builder()
+            .email(email)
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .products(List.of(
+                product1,
+                product2
+            ))
+            .build();
+
+        Order order2 = Order.builder()
+            .email(email)
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProducts(Map.of(1L, 2, 3L, 4))
+            .products(List.of(
+                product1,
+                product3
+            ))
+            .build();
+
+        orderRepository.saveAll(List.of(order1, order2));
+
+        //when
+        List<Order> findOrdersByEmail = orderRepository.findByEmail(email);
+
+        //then
+        assertThat(findOrdersByEmail).hasSize(2)
+            .extracting("email", "address", "postcode", "orderStatus")
+            .containsExactlyInAnyOrder(
+                tuple("test@gmail.com", "서울시 강남구", "125454", ORDERED),
+                tuple("test@gmail.com", "서울시 강남구", "125454", ORDERED)
+            );
+
+        assertThat(findOrdersByEmail.get(0).getOrderProducts()).hasSize(2)
+            .extracting("category", "price", "quantity")
+            .containsExactlyInAnyOrder(
+                tuple("원두", 50000L, 1),
+                tuple("음료", 3000L, 2)
+            );
+
+        assertThat(findOrdersByEmail.get(1).getOrderProducts()).hasSize(2)
+            .extracting("category", "price", "quantity")
+            .containsExactlyInAnyOrder(
+                tuple("원두", 50000L, 2),
+                tuple("베이커리", 5000L, 4)
+            );
+
+    }
+
+    @DisplayName("주문 상태로 주문 목록을 조회한다.")
+    @Test
+    void findOrdersByOrderStatus() {
+        //given
+        Product product1 = Product.builder()
+            .name("스타벅스 원두")
+            .category("원두")
+            .price(50000L)
+            .description("에티오피아산")
+            .build();
+
+        Product product2 = Product.builder()
+            .name("스타벅스 라떼")
+            .category("음료")
+            .price(3000L)
+            .description("에스프레소")
+            .build();
+
+        Product product3 = Product.builder()
+            .name("스타벅스 베이글")
+            .category("베이커리")
+            .price(5000L)
+            .description("베이글")
+            .build();
+
+        productRepository.saveAll(List.of(product1, product2,product3));
+
+        Order order1 = Order.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProducts(Map.of(1L, 1, 2L, 2))
+            .products(List.of(
+                product1,
+                product2
+            ))
+            .build();
+
+        Order order2 = Order.builder()
+            .email("test@gmail.com")
+            .address("서울시 강남구")
+            .postcode("125454")
+            .orderProducts(Map.of(1L, 2, 3L, 4))
+            .products(List.of(
+                product1,
+                product3
+            ))
+            .build();
+
+        orderRepository.saveAll(List.of(order1, order2));
+        //when
+        List<Order> findOrdersByOrderStatus = orderRepository.findByOrderStatus(ORDERED);
+        //then
+        assertThat(findOrdersByOrderStatus).hasSize(2)
+            .extracting("email", "address", "postcode", "orderStatus")
+            .containsExactlyInAnyOrder(
+                tuple("test@gmail.com", "서울시 강남구", "125454", ORDERED),
+                tuple("test@gmail.com", "서울시 강남구", "125454", ORDERED)
+            );
+
+        assertThat(findOrdersByOrderStatus.get(0).getOrderProducts()).hasSize(2)
+            .extracting("category", "price", "quantity")
+            .containsExactlyInAnyOrder(
+                tuple("원두", 50000L, 1),
+                tuple("음료", 3000L, 2)
+            );
+
+        assertThat(findOrdersByOrderStatus.get(1).getOrderProducts()).hasSize(2)
+            .extracting("category", "price", "quantity")
+            .containsExactlyInAnyOrder(
+                tuple("원두", 50000L, 2),
+                tuple("베이커리", 5000L, 4)
+            );
+    }
+}


### PR DESCRIPTION
- 주문 상태 변경은 스케쥴러를 사용해서 변경하도록 하였습니다.
ㄴ 다른 API 들이 실행 여부와 상관없이 실행하기 위해 비동기로 처리하였습니다.
ㄴ 비동기 처리시 테스트에 어려움이 생겨 테스트시에는 동기처리를 하도록 하였습니다.

- 신규 주문 생성의 요청이 변경되었습니다.